### PR TITLE
Template Link Initializer

### DIFF
--- a/sources/KakaoSDKTemplate/model/TemplateModels.swift
+++ b/sources/KakaoSDKTemplate/model/TemplateModels.swift
@@ -127,6 +127,16 @@ public struct Link : Codable {
         self.androidExecutionParams = androidExecutionParams?.queryParameters
         self.iosExecutionParams = iosExecutionParams?.queryParameters
     }
+
+    public init(webUrl: URL? = nil,
+                mobileWebUrl: URL? = nil,
+                androidExecutionParams: String? = nil,
+                iosExecutionParams: String? = nil) {
+        self.webUrl = webUrl
+        self.mobileWebUrl = mobileWebUrl
+        self.androidExecutionParams = androidExecutionParams
+        self.iosExecutionParams = iosExecutionParams
+    }
 }
 
 /// 컨텐츠의 내용을 담고 있는 오브젝트 입니다. **1개의 이미지, 제목, 설명, 링크** 정보를 가질 수 있습니다.


### PR DESCRIPTION
[문제점]
레거시 코드에서는 androidExecutionParams와 iosExecutionParams의 타입이 프로퍼티와 동일하게 `String? ` 이었지만, 현재는 `[String: String]?` 로만 만들 수 있어서 기존 코드와 동일한 사용성에 대한 대응이 불가해보입니다.

[수정 사항]
기존 사용 코드에 대응할 수 있는 initialize 추가

[확인이 필요한 부분]
프로퍼티 이름에 params가 포함되어있어 혼란이 야기되어보입니다.
params 대신 deeplink 라는 표현이 더 맞는 것 같아 확인이 필요해 보입니다.

제가 의도와 다른 방향으로 사용하고 있거나 잘 못 인지하고 있는 부분이 있으면 알려주시기 바랍니다.